### PR TITLE
chapter_exeのオプションを設定可能にしました

### DIFF
--- a/Amatsukaze/AmatsukazeCLI.hpp
+++ b/Amatsukaze/AmatsukazeCLI.hpp
@@ -385,6 +385,9 @@ static std::unique_ptr<ConfigWrapper> parseArgs(AMTContext& ctx, int argc, const
 		else if (key == _T("--chapter-exe")) {
 			conf.chapterExePath = getParam(argc, argv, i++);
 		}
+		else if (key == _T("--chapter-exe-options")) {
+		conf.chapterExeOptions = getParam(argc, argv, i++);
+		}
 		else if (key == _T("--jls")) {
 			conf.joinLogoScpPath = getParam(argc, argv, i++);
 		}

--- a/Amatsukaze/CMAnalyze.hpp
+++ b/Amatsukaze/CMAnalyze.hpp
@@ -281,9 +281,10 @@ private:
 
   tstring MakeChapterExeArgs(int videoFileIndex, const tstring& avspath)
 	{
-		return StringFormat(_T("\"%s\" -v \"%s\" -o \"%s\""),
+		return StringFormat(_T("\"%s\" -v \"%s\" -o \"%s\" %s"),
 			setting_.getChapterExePath(), avspath,
-			setting_.getTmpChapterExePath(videoFileIndex));
+			setting_.getTmpChapterExePath(videoFileIndex),
+			setting_.getChapterExeOptions());
 	}
 
 	void chapterExe(int videoFileIndex, const tstring& avspath)

--- a/Amatsukaze/TranscodeSetting.hpp
+++ b/Amatsukaze/TranscodeSetting.hpp
@@ -478,6 +478,7 @@ struct Config {
 	bool noDelogo;
 	bool vfr120fps;
   tstring chapterExePath;
+  tstring chapterExeOptions;
   tstring joinLogoScpPath;
   tstring joinLogoScpCmdPath;
   tstring joinLogoScpOptions;
@@ -677,6 +678,10 @@ public:
   tstring getChapterExePath() const {
 		return conf.chapterExePath;
 	}
+
+  tstring getChapterExeOptions() const {
+	  return conf.chapterExeOptions;
+  }
 
   tstring getJoinLogoScpPath() const {
 		return conf.joinLogoScpPath;

--- a/AmatsukazeGUI/Models/ClientModel.cs
+++ b/AmatsukazeGUI/Models/ClientModel.cs
@@ -1321,6 +1321,7 @@ namespace Amatsukaze.Models
                 profile.JLSCommandFile = data.Profile.JLSCommandFile;
                 profile.JLSOption = data.Profile.JLSOption;
                 profile.EnableJLSOption = data.Profile.EnableJLSOption;
+                profile.ChapterExeOptions = data.Profile.ChapterExeOption;
                 profile.DisableChapter = data.Profile.DisableChapter;
                 profile.DisableSubs = data.Profile.DisableSubs;
                 profile.IgnoreNoDrcsMap = data.Profile.IgnoreNoDrcsMap;

--- a/AmatsukazeGUI/Models/DisplayData.cs
+++ b/AmatsukazeGUI/Models/DisplayData.cs
@@ -1149,6 +1149,20 @@ namespace Amatsukaze.Models
         }
         #endregion
 
+        #region ChapterExeOptions変更通知プロパティ
+        public string ChapterExeOptions
+        {
+            get { return Data.ChapterExeOption; }
+            set
+            {
+                if (Data.ChapterExeOption == value)
+                    return;
+                Data.ChapterExeOption = value;
+                RaisePropertyChanged();
+            }
+        }
+        #endregion
+
         #region EnableJLSOption変更通知プロパティ
         public bool EnableJLSOption {
             get { return Data.EnableJLSOption; }
@@ -1859,6 +1873,7 @@ namespace Amatsukaze.Models
             text.KeyValue("エンコーダオプション", EncoderOption);
             text.KeyValue("JoinLogoScpコマンドファイル", Data.JLSCommandFile ?? "チャンネル設定に従う");
             text.KeyValue("JoinLogoScpオプション", Data.JLSOption ?? "チャンネル設定に従う");
+            text.KeyValue("chapter_exeオプション", Data.ChapterExeOption);
             text.KeyValue("メインフィルタ", Data.FilterPath);
             text.KeyValue("ポストフィルタ", Data.PostFilterPath);
             text.KeyValue("MPEG2デコーダ", Mpeg2DecoderList[(int)Data.Mpeg2Decoder]);

--- a/AmatsukazeGUI/Views/ProfileSettingPanel.xaml
+++ b/AmatsukazeGUI/Views/ProfileSettingPanel.xaml
@@ -78,6 +78,7 @@
 
                     <TextBlock HorizontalAlignment="Right" VerticalAlignment="Top" TextAlignment="Right">JoinLogoScp<LineBreak/>コマンドファイル</TextBlock>
                     <TextBlock HorizontalAlignment="Right" Text="オプション" VerticalAlignment="Top" Margin="0"/>
+                    <TextBlock HorizontalAlignment="Right" Text="chapter_exeオプション" VerticalAlignment="Top" Margin="0,6"/>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Margin="10,0">
@@ -120,6 +121,8 @@
                                  Text="{Binding Model.SelectedProfile.JLSOption, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                  IsEnabled="{Binding Model.SelectedProfile.EnableJLSOption, Mode=OneWay}"/>
                     </DockPanel>
+                    <TextBox Margin="0,3" ToolTip="chapter_exeのオプション"
+                             Text="{Binding Model.SelectedProfile.ChapterExeOptions, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                 </StackPanel>
 

--- a/AmatsukazeServer/Server/EncodeServer.cs
+++ b/AmatsukazeServer/Server/EncodeServer.cs
@@ -980,7 +980,7 @@ namespace Amatsukaze.Server
             bool isGeneric,
             string src, string dst, string json,
             int serviceId, string[] logofiles,
-            bool ignoreNoLogo, string jlscommand, string jlsopt,
+            bool ignoreNoLogo, string jlscommand, string jlsopt, string ceopt,
             string inHandle, string outHandle, int pid)
         {
             StringBuilder sb = new StringBuilder();
@@ -1209,6 +1209,12 @@ namespace Amatsukaze.Server
                 {
                     sb.Append(" --jls-option \"")
                         .Append(jlsopt)
+                        .Append("\"");
+                }
+                if (string.IsNullOrEmpty(ceopt) == false)
+                {
+                    sb.Append(" --chapter-exe-options \"")
+                        .Append(ceopt)
                         .Append("\"");
                 }
 

--- a/AmatsukazeServer/Server/EncodeServerData.cs
+++ b/AmatsukazeServer/Server/EncodeServerData.cs
@@ -210,6 +210,8 @@ namespace Amatsukaze.Server
         [DataMember]
         public string JLSOption { get; set; }
         [DataMember]
+        public string ChapterExeOption { get; set; }
+        [DataMember]
         public bool EnableJLSOption { get; set; }
         [DataMember]
         public bool DisableChapter { get; set; }

--- a/AmatsukazeServer/Server/TranscodeWorker.cs
+++ b/AmatsukazeServer/Server/TranscodeWorker.cs
@@ -853,13 +853,14 @@ namespace Amatsukaze.Server
                 string jlsopt = (serviceSetting?.DisableCMCheck ?? true) ? null
                     : profile.EnableJLSOption ? profile.JLSOption
                     : serviceSetting.JLSOption;
+                string ceopt = (serviceSetting?.DisableCMCheck ?? true) ? null : profile.ChapterExeOption;
 
                 string args = server.MakeAmatsukazeArgs(
                     item.Mode, profile,
                     server.AppData_.setting,
                     isMp4,
                     srcpath, localdst + ext, json,
-                    item.ServiceId, logopaths, ignoreNoLogo, jlscmd, jlsopt,
+                    item.ServiceId, logopaths, ignoreNoLogo, jlscmd, jlsopt, ceopt,
                     pipes?.InHandle, pipes?.OutHandle, Id);
                 string exename = server.AppData_.setting.AmatsukazePath;
 


### PR DESCRIPTION
chapter_exe のオプションをプロファイルごとに設定可能にしました。

これまでは -m (無音閾値) -s (連続フレーム数) の指定は省略され、デフォルト (-m 100 -s 15) で実行されていましたが、
プロファイル設定から例えば "-m 50 -s 5" と明示的に与えることが出来るようになります。 